### PR TITLE
slightly faster ARM kernel

### DIFF
--- a/src/Base64ARM.cs
+++ b/src/Base64ARM.cs
@@ -344,23 +344,15 @@ namespace SimdBase64
                 // Load 4 vectors from src
                 var (str0, str1, str2, str3) = AdvSimd.Arm64.Load4xVector128AndUnzip(srcPtr);
 
-
-
                 // Perform bitwise operations to simulate NEON intrinsics
-                Vector128<byte> outvec0 = AdvSimd.Or(
-                    AdvSimd.ShiftLeftLogical(str0, 2),
-                    AdvSimd.ShiftRightLogical(str1, 4)
-                );
+                Vector128<byte> outvec0 = AdvSimd.ShiftLeftAndInsert(
+                    AdvSimd.ShiftRightLogical(str1, 4), str0, 2);
 
-                Vector128<byte> outvec1 = AdvSimd.Or(
-                    AdvSimd.ShiftLeftLogical(str1, 4),
-                    AdvSimd.ShiftRightLogical(str2, 2)
-                );
+                Vector128<byte> outvec1 = AdvSimd.ShiftLeftAndInsert(
+                    AdvSimd.ShiftRightLogical(str2, 2), str1, 4);
 
-                Vector128<byte> outvec2 = AdvSimd.Or(
-                    AdvSimd.ShiftLeftLogical(str2, 6),
-                    str3
-                );
+                Vector128<byte> outvec2 = AdvSimd.ShiftLeftAndInsert(
+                    str3, str2, 6);
 
                 // Store the result in outData
                 AdvSimd.Arm64.StoreVectorAndZip(outPtr, (outvec0, outvec1, outvec2));


### PR DESCRIPTION
Before

|                              Method |                    FileName |        Mean |     Error |    StdDev | kiB/input | Speed (GB/s) |
|------------------------------------ |---------------------------- |------------:|----------:|----------:|---------- |------------- |
|      SimdBase64DecodingRealDataUTF8 | data/dns/swedenzonebase.txt | 18,531.0 us | 233.38 us | 239.67 us |       .35 |         1.89 |
|      SimdBase64DecodingRealDataUTF8 |                 data/email/ |    226.2 us |   8.19 us |   9.43 us |    131.77 |         8.74 |


After

|                              Method |                    FileName |        Mean |     Error |    StdDev | kiB/input | Speed (GB/s) |
|------------------------------------ |---------------------------- |------------:|----------:|----------:|---------- |------------- |
|      SimdBase64DecodingRealDataUTF8 | data/dns/swedenzonebase.txt | 18,414.7 us | 177.56 us | 189.98 us |       .35 |         1.91 |
|      SimdBase64DecodingRealDataUTF8 |                 data/email/ |    200.5 us |   1.51 us |   1.61 us |    131.77 |         9.86 |